### PR TITLE
Fix invalid language schema

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -75,7 +75,7 @@ impl From<SeriesSearchData> for EpisodeId {
 #[serde(rename_all = "camelCase")]
 pub struct JSONErrors {
     pub invalid_filters: Option<Vec<String>>,
-    pub invalid_language: Option<Vec<String>>,
+    pub invalid_language: Option<String>,
     pub invalid_query_params: Option<Vec<String>>,
 }
 


### PR DESCRIPTION
Fix the invalid language schema since it is actually only a string, not a vector of strings.

See: https://api.thetvdb.com/swagger#!/Series/get_series_id_episodes

![image](https://user-images.githubusercontent.com/7073910/89708169-52caa700-d9a7-11ea-8c64-2c2a7f826972.png)
