### PR TITLE
chore: Minor change to replace http by https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.0"
 authors = ["dbr <dbr.onix@gmail.com>"]
 
 description = "API wrapper to http://thetvdb.com (open database for TV episode data)"
-repository = "http://github.com/dbr/tvdb-rs"
+repository = "https://github.com/dbr/tvdb-rs"
 readme = "readme.md"
 keywords = ["api", "tvdb", "web"]
 license = "Unlicense"


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97